### PR TITLE
Rotary Half step support

### DIFF
--- a/config.c
+++ b/config.c
@@ -108,7 +108,7 @@ int init_config(void)
   FILE *fp;
   char ln[MAX_LN];
   int lnno = 0;
-  char name[32], xname[32], keya[32], keyb[32];
+  char name[32], xname[32], keya[32], keyb[32], rotHalf[5];
   char conffile[80];
   int gpio,caddr,regno,gpio2;
 
@@ -148,7 +148,7 @@ int init_config(void)
 	    }
 	  }
           else if(strstr(ln, "ROT") == ln){
-            n=sscanf(ln, "%s %d %d %s %s", name, &gpio, &gpio2, &keya, &keyb);
+            n=sscanf(ln, "%s %d %d %s %s %s", name, &gpio, &gpio2, &keya, &keyb, &rotHalf);
             if (n == 5) {
               ka = find_key(keya);
               kb = find_key(keyb);

--- a/pikeyd.conf
+++ b/pikeyd.conf
@@ -32,7 +32,9 @@ KEY_L		21
 KEY_O		21
 
 # Set up a rotary encoder generating up & down arrow keys, using GPIOs 4 and 17 for gray code input
-ROT 4 17 KEY_DOWN KEY_UP
+ROT 4 17 KEY_DOWN KEY_UP 0
+# Same as above only it uses a rotary which works with half steps each click
+ROT 5 18 KEY_DOWN KEY_UP 1
 
 #define I/O expanders before using them
 #XIO(tag) gpio_int_pin/chip_addr:register_no


### PR DESCRIPTION
Hi @dozencrows,

  i like your patch for  rotary :) But my rotary encoder from Panasonic only supports half steps. With your code i had to turn the encoder two steps to get an input.
I patched it so it supports my encoder to :)

The only thing which differs in the configuration from yours is that the user must add a 0 or a 1 when to enable the half step support.
